### PR TITLE
Use OpenWeather API 3.0 for current weather

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -49,7 +49,7 @@ async function callApi(endpoint: string, params: Record<string, string>) {
 
 async function getCurrentWeather(args: CommonArgs) {
   const params = await buildParams(args);
-  return callApi("https://api.openweathermap.org/data/2.5/weather", params);
+  return callApi("https://api.openweathermap.org/data/3.0/weather", params);
 }
 
 async function getForecast(args: CommonArgs) {


### PR DESCRIPTION
## Summary
- switch current weather endpoint to 3.0

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685123a9ce9083338ebc720cdd44462c