### PR TITLE
Improve Docker build process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+.git
+Dockerfile
+.dockerignore
+dist
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,15 @@
-FROM node:20
+FROM node:20 AS builder
 WORKDIR /app
 COPY package.json package-lock.json* ./
-RUN npm install --production && npm cache clean --force
+# Install all dependencies including dev packages for building
+RUN npm ci
 COPY . .
 RUN npm run build
+
+FROM node:20 AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev && npm cache clean --force
+COPY --from=builder /app/dist ./dist
 CMD ["node", "dist/server.js"]

--- a/README.md
+++ b/README.md
@@ -30,3 +30,13 @@ Then in Open WebUI go to **Settings ▸ Tools ▸ Add OpenAPI Server** and enter
 http://localhost:8080
 ```
 
+## Docker
+
+Build the container image locally:
+```bash
+docker build -t weather-mcp .
+```
+The Dockerfile now performs a multi-stage build to install development
+dependencies only during the build phase and keep the final runtime image
+lightweight.
+


### PR DESCRIPTION
## Summary
- update Dockerfile to a multi-stage build that installs dev dependencies only during build
- add .dockerignore to reduce context sent to Docker
- document Docker build instructions in README

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68516b611ed883339ed71339ec34cc47