### PR TITLE
Fix grammatical error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ Build the container image locally:
 docker build -t weather-mcp .
 ```
 The Dockerfile now performs a multi-stage build to install development
-dependencies only during the build phase and keep the final runtime image
+dependencies only during the build phase while keeping the final runtime image
 lightweight.
 


### PR DESCRIPTION
## Summary
- fix a typo in Docker instructions by replacing `and keep` with `while keeping`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68518e85edd08333b09c0fc278e0c12a