### PR TITLE
Add buildParams validation tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "tsx watch src/server.ts",
     "build": "tsc",
     "start": "node dist/server.js",
-    "mcpo": "mcpo --port 8080 -- node dist/server.js"
+    "mcpo": "mcpo --port 8080 -- node dist/server.js",
+    "test": "tsx --test test/*.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.3",

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,10 +5,6 @@ import { request } from "undici";
 import "dotenv/config";
 
 const API_KEY = process.env.OPENWEATHERMAP_API_KEY;
-if (!API_KEY) {
-  console.error("Missing OPENWEATHERMAP_API_KEY in environment");
-  process.exit(1);
-}
 
 const server = new McpServer({ name: "openweather-ts", version: "0.1.0" });
 
@@ -24,9 +20,10 @@ const commonSchema = z
     message: "Provide city or both lat and lon",
   });
 
-type CommonArgs = z.infer<typeof commonSchema>;
+export type CommonArgs = z.infer<typeof commonSchema>;
 
-async function buildParams(args: CommonArgs, exclude?: string) {
+export async function buildParams(args: CommonArgs, exclude?: string) {
+  commonSchema.parse(args);
   const params: Record<string, string> = {
     units: args.units ?? "metric",
     appid: API_KEY!,
@@ -81,6 +78,10 @@ server.registerTool(
 );
 
 if (import.meta.url === `file://${process.argv[1]}`) {
+  if (!API_KEY) {
+    console.error("Missing OPENWEATHERMAP_API_KEY in environment");
+    process.exit(1);
+  }
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/test/buildParams.test.ts
+++ b/test/buildParams.test.ts
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildParams } from '../src/server.ts';
+
+// BuildParams should reject when called with missing lon
+
+test('buildParams fails with missing lon', async () => {
+  await assert.rejects(
+    buildParams({ lat: 12.34 } as any),
+    { message: /Provide city or both lat and lon/ }
+  );
+});
+
+test('buildParams fails with missing lat', async () => {
+  await assert.rejects(
+    buildParams({ lon: 56.78 } as any),
+    { message: /Provide city or both lat and lon/ }
+  );
+});


### PR DESCRIPTION
## Summary
- export `buildParams` and `CommonArgs`
- enforce validation in `buildParams`
- move API key check to runtime only
- add unit tests for missing coordinate cases
- enable tests via `npm test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68518e989ab88333b0474a330b825747