### PR TITLE
Fix container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ FROM node:20 AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
 COPY package.json package-lock.json* ./
-RUN npm ci --omit=dev && npm cache clean --force
+RUN npm ci --omit=dev && npm cache clean --force \
+    && apt-get update && apt-get install -y --no-install-recommends python3 python3-pip \
+    && pip3 install --no-cache-dir mcpo \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/dist ./dist
-CMD ["node", "dist/server.js"]
+ENTRYPOINT ["mcpo"]
+CMD ["--port", "8080", "--", "node", "dist/server.js"]

--- a/README.md
+++ b/README.md
@@ -33,11 +33,14 @@ http://localhost:8080
 
 ## Docker
 
-Build the container image locally:
+Build the container image locally (this image now includes the `mcpo` proxy):
 ```bash
 docker build -t weather-mcp .
 ```
-The Dockerfile now performs a multi-stage build to install development
-dependencies only during the build phase while keeping the final runtime image
-lightweight.
+Run the server via Docker:
+```bash
+docker run -p 8080:8080 --env-file .env weather-mcp
+```
+The Dockerfile performs a multi-stage build to install development dependencies
+only during the build phase while keeping the final runtime image lightweight.
 


### PR DESCRIPTION
## Summary
- install Python and `mcpo` into runtime Docker image
- run server via `mcpo` in Docker
- document docker run instructions

## Testing
- `npm ci`
- `OPENWEATHERMAP_API_KEY=dummy npm test`

------
https://chatgpt.com/codex/tasks/task_e_68519237ae9c833385564e28b91ee798