### PR TITLE
Fix compose to use local mcpo build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV NODE_ENV=production
 COPY package.json package-lock.json* ./
 RUN npm ci --omit=dev && npm cache clean --force \
     && apt-get update && apt-get install -y --no-install-recommends python3 python3-pip \
-    && pip3 install --no-cache-dir mcpo \
+    && pip3 install --no-cache-dir --break-system-packages mcpo \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/dist ./dist
 ENTRYPOINT ["mcpo"]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Simple MCP server wrapping OpenWeatherMap.
 
 ## Open WebUI
 
-Run the proxy and server together (from the `docker` directory):
+Run the proxy and server together using Docker Compose
+(from the `docker` directory). Compose will build the
+container from the included `Dockerfile`:
 ```bash
 cd docker
 docker compose up -d

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,10 +1,6 @@
 services:
-  mcpo:
-    image: ghcr.io/open-webui/mcpo:latest
-    command: ["--port", "8080", "--", "node", "/app/dist/server.js"]
+  mcp:
+    build: ..
     env_file: ../.env
-    volumes:
-      - ..:/app:ro
     ports:
       - "8080:8080"
-


### PR DESCRIPTION
## Summary
- build the mcpo image locally when using Docker Compose
- clarify compose instructions in the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685193f01eb083339f58840b29f35e8a